### PR TITLE
Add support for TestPort command using Test-NetConnection

### DIFF
--- a/PoshBot.Networking/PoshBot.Networking.psm1
+++ b/PoshBot.Networking/PoshBot.Networking.psm1
@@ -68,4 +68,36 @@ function Invoke-Dig {
     }
 }
 
-Export-ModuleMember -Function 'Invoke-Ping', 'Invoke-Dig'
+function Invoke-TestPort {
+    <#
+    .SYNOPSIS
+        Perform port testing on a host
+    .EXAMPLE
+        !testport (srv.domain.local | --ComputerName src.domain.local) [--Port 443]
+    #>
+    [PoshBot.BotCommand(
+        CommandName = 'testport',
+        Permissions = 'test-network'
+    )]
+    [cmdletbinding()]
+    param(
+        [parameter(Mandatory)]
+        [Alias('Name')]
+        [string]$ComputerName,
+
+        [parameter(Mandatory)]
+        [string]$Port
+    )
+
+    $r = Test-NetConnection -ComputerName $ComputerName -Port $Port -ErrorAction SilentlyContinue | Format-Table -Autosize | Out-String
+
+    if ($r) {
+        New-PoshBotCardResponse -Type Normal -Text $r
+    } else {
+        New-PoshBotCardResponse -Type Warning -Text "Unable to resolve [$Name] :(" -Title 'Rut row' -ThumbnailUrl 'http://images4.fanpop.com/image/photos/17000000/Scooby-Doo-Where-Are-You-The-Original-Intro-scooby-doo-17020515-500-375.jpg'
+    }
+}
+
+
+
+Export-ModuleMember -Function 'Invoke-Ping', 'Invoke-Dig', 'Invoke-TestPort'

--- a/PoshBot.Networking/PoshBot.Networking.psm1
+++ b/PoshBot.Networking/PoshBot.Networking.psm1
@@ -89,12 +89,19 @@ function Invoke-TestPort {
         [string]$Port
     )
 
-    $r = Test-NetConnection -ComputerName $ComputerName -Port $Port -ErrorAction SilentlyContinue | Format-Table -Autosize | Out-String
-
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        $r = Test-Connection -TargetName $ComputerName -TCPPort $Port -ErrorAction SilentlyContinue |
+                Select-Object @{Name ='ComputerName';Expression={$ComputerName}},@{Name='Port';Expression={$Port}},@{Name='Result';Expression={$_}} |
+                Format-Table -Autosize |
+                Out-String
+    }
+    else {
+        $r = Test-NetConnection -ComputerName $ComputerName -Port $Port -ErrorAction SilentlyContinue | Format-Table -Autosize | Out-String
+    }
     if ($r) {
         New-PoshBotCardResponse -Type Normal -Text $r
     } else {
-        New-PoshBotCardResponse -Type Warning -Text "Unable to resolve [$Name] :(" -Title 'Rut row' -ThumbnailUrl 'http://images4.fanpop.com/image/photos/17000000/Scooby-Doo-Where-Are-You-The-Original-Intro-scooby-doo-17020515-500-375.jpg'
+        New-PoshBotCardResponse -Type Warning -Text "Unable to resolve [$ComputerName] :(" -Title 'Rut row' -ThumbnailUrl 'http://images4.fanpop.com/image/photos/17000000/Scooby-Doo-Where-Are-You-The-Original-Intro-scooby-doo-17020515-500-375.jpg'
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -70,3 +70,17 @@ Name       Type TTL Section   PrimaryServer  NameAdministrator    SerialNumber
 ----       ---- --- -------   -------------  -----------------    ------------
 google.com SOA  59  Authority ns4.google.com dns-admin.google.com 150821008
 ```
+
+```
+!testport server1 443
+ComputerName RemotePort RemoteAddress PingSucceeded PingReplyDetails (RTT) TcpTestSucceeded
+------------ ---------- ------------- ------------- ---------------------- ----------------
+server1       443        1.2.3.4      False                                True
+```
+
+```
+!testport --computername server2  --port 5986
+ComputerName RemotePort RemoteAddress PingSucceeded PingReplyDetails (RTT) TcpTestSucceeded
+------------ ---------- ------------- ------------- ---------------------- ----------------
+server2       5986       1.2.3.4      False                                True
+```


### PR DESCRIPTION
Add Invoke-TestPort to allow testing ports on remote machines. It makes use of Test-NetConnection to do this and could be extended to make use of the other options within that at a later date.

## Related Issue
Solves part of #1

## How Has This Been Tested?
Tested from MS Teams against a few different port and server variations. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
